### PR TITLE
Add CLI for FastMCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,33 @@ curl -X POST http://localhost:8000/initialize
 ```
 
 This returns a JSON object listing the supported tool names.
+
+## Using the FastMCP Client
+
+A minimal client implementation is included in `client/client.py`. You can use
+it to interact with the server programmatically:
+
+```python
+from client.client import FastMCPClient
+
+client = FastMCPClient("http://localhost:8000")
+
+# Discover available tools
+print(client.initialize())
+
+# Call a specific tool
+result = client.query("all_stocks", params={"date": "20240101"})
+print(result)
+```
+
+Alternatively you can run the client from the command line. This requires the
+server to be running first:
+
+```bash
+# List the available tools
+python -m client --list-tools
+
+# Query a specific tool with optional parameters
+python -m client all_stocks --param date=20240101
+```
+

--- a/client/__main__.py
+++ b/client/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == '__main__':
+    main()

--- a/client/cli.py
+++ b/client/cli.py
@@ -1,0 +1,38 @@
+import argparse
+from .client import FastMCPClient
+
+
+def parse_params(param_list: list[str]) -> dict[str, str]:
+    params = {}
+    for p in param_list:
+        if '=' not in p:
+            raise argparse.ArgumentTypeError(f"Invalid parameter '{p}', expected key=value")
+        key, value = p.split('=', 1)
+        params[key] = value
+    return params
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Command line interface for FastMCP")
+    parser.add_argument('--base-url', default='http://localhost:8000', help='FastMCP server base URL')
+    parser.add_argument('--list-tools', action='store_true', help='List available tools and exit')
+    parser.add_argument('--param', action='append', default=[], help='Query parameter in key=value format (can be used multiple times)')
+    parser.add_argument('tool', nargs='?', help='Name of the tool to query')
+    args = parser.parse_args()
+
+    client = FastMCPClient(args.base_url)
+
+    if args.list_tools:
+        print(client.initialize())
+        return
+
+    if not args.tool:
+        parser.error('tool is required unless --list-tools is specified')
+
+    params = parse_params(args.param)
+    result = client.query(args.tool, params=params or None)
+    print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/client/client.py
+++ b/client/client.py
@@ -1,0 +1,23 @@
+import requests
+
+
+class FastMCPClient:
+    """Simple client for interacting with the FastMCP server."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+
+    def initialize(self) -> dict:
+        """Retrieve the list of available tools from the server."""
+        url = f"{self.base_url}/initialize"
+        response = requests.post(url, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def query(self, tool_name: str, params: dict | None = None) -> dict:
+        """Call a specific tool on the server."""
+        url = f"{self.base_url}/query/{tool_name}"
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json()
+


### PR DESCRIPTION
## Summary
- implement a simple command-line interface to query the FastMCP server
- document how to use the CLI in the README

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68476dcaf69c83239f51b3ff84e63f25