### PR TITLE
Add OpenAPI spec for TWSE allStocks endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ python -m client --list-tools
 python -m client all_stocks --param date=20240101
 ```
 
+## OpenAPI Document
+
+An OpenAPI specification describing the available TWSE endpoints is
+provided in `openapi/openapi.yaml`. The `allStocks` endpoint can be used to
+retrieve trading information for all listed stocks on a given date.
+

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,70 @@
+openapi: 3.0.1
+info:
+  title: TWSE OpenAPI
+  description: |
+    This OpenAPI specification describes a subset of the Taiwan Stock Exchange
+    (TWSE) OpenAPI service. The `/v1/tradingInfo/allStocks` endpoint provides
+    daily trading data for all listed stocks on a specific date.
+  version: "1.0.0"
+servers:
+  - url: https://openapi.twse.com.tw
+paths:
+  /v1/tradingInfo/allStocks:
+    get:
+      summary: Retrieve daily trading information for all TWSE listed stocks.
+      description: |
+        Returns a list of trading information for all stocks on the specified
+        date. The `date` query parameter uses the `YYYYMMDD` format and is
+        required.
+      parameters:
+        - name: date
+          in: query
+          description: Date of the trading data in `YYYYMMDD` format.
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response containing stock information.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    Code:
+                      type: string
+                      description: Stock code.
+                    Name:
+                      type: string
+                      description: Stock name.
+                    TradeVolume:
+                      type: integer
+                      description: Trading volume.
+                    TradeValue:
+                      type: integer
+                      description: Trading value in NTD.
+                    OpeningPrice:
+                      type: number
+                      format: float
+                      description: Opening price for the date.
+                    HighestPrice:
+                      type: number
+                      format: float
+                      description: Highest price for the date.
+                    LowestPrice:
+                      type: number
+                      format: float
+                      description: Lowest price for the date.
+                    ClosingPrice:
+                      type: number
+                      format: float
+                      description: Closing price for the date.
+                    Change:
+                      type: number
+                      format: float
+                      description: Price change from the previous close.
+                  required:
+                    - Code
+                    - Name


### PR DESCRIPTION
## Summary
- document the OpenAPI location in README
- provide `openapi/openapi.yaml` describing `/v1/tradingInfo/allStocks`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68476fa1e7dc832386c246f9343625fd